### PR TITLE
imgur HTTP Access Disabled; use HTTPS instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,8 +137,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>11</source>
+                    <target>11</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/com/github/imgur/ImgUrRequestProvider.java
+++ b/src/main/java/com/github/imgur/ImgUrRequestProvider.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class ImgUrRequestProvider implements RequestProvider {
 
-    private static final String IMGUR_BASE_URL = "http://api.imgur.com/3/";
+    private static final String IMGUR_BASE_URL = "https://api.imgur.com/3/";
 
     private final String apiKey;
     private final OAuthService oauth;


### PR DESCRIPTION
The other commit was upping the JDK version, as maven was complaining about it. 